### PR TITLE
Use fields attribute if form is an instance

### DIFF
--- a/djangojsonschema/jsonschema.py
+++ b/djangojsonschema/jsonschema.py
@@ -1,6 +1,6 @@
 #TODO find a better submodule name
 from django.forms import widgets, fields
-
+import inspect
 
 def pretty_name(name):
     """Converts 'first_name' to 'First name'"""
@@ -17,8 +17,14 @@ class DjangoFormToJSONSchema(object):
                 'type':'object',
                 'properties':{}, #TODO SortedDict
             }
-        #CONSIDER: base_fields when given a class, fields for when given an instance
-        for name, field in form.base_fields.iteritems():
+        fields = form.base_fields
+
+        # If a Form instance is given, use the 'fields' attribute if it exists
+        # since instances are allowed to modify them.
+        if not inspect.isclass(form) and hasattr(form, 'fields'):
+            fields = form.fields
+
+        for name, field in fields.iteritems():
             json_schema['properties'][name] = self.convert_formfield(name, field, json_schema)
         return json_schema
 

--- a/djangojsonschema/jsonschema.py
+++ b/djangojsonschema/jsonschema.py
@@ -21,11 +21,11 @@ class DjangoFormToJSONSchema(object):
         for name, field in form.base_fields.iteritems():
             json_schema['properties'][name] = self.convert_formfield(name, field, json_schema)
         return json_schema
-    
+
     input_type_map = {
         'text': 'string',
     }
-    
+
     def convert_formfield(self, name, field, json_schema):
         #TODO detect bound field
         widget = field.widget
@@ -71,7 +71,7 @@ class DjangoFormToJSONSchema(object):
         else:
             target_def['type'] = 'string'
         return target_def
-        
+
 class DjangoModelToJSONSchema(DjangoFormToJSONSchema):
     def convert_model(self, model, json_schema=None):
         model_form = None #TODO convert to model form
@@ -91,7 +91,7 @@ class DocKitSchemaToJSONSchema(DjangoFormToJSONSchema):
         for key, field in dockit_schema._meta.fields.iteritems():
             json_schema['properties'][key] = self.convert_dockitfield(key, field, json_schema)
         return json_schema
-    
+
     def convert_dockitfield(self, name, field, json_schema):
         #if simple field, get the form field
         if True: #TODO is simple

--- a/djangojsonschema/tests/test_form_to_jsonschema.py
+++ b/djangojsonschema/tests/test_form_to_jsonschema.py
@@ -37,7 +37,7 @@ class TestForm(forms.Form):
 class FormToJsonSchemaTestCase(unittest.TestCase):
     def setUp(self):
         self.encoder = DjangoFormToJSONSchema()
-    
+
     def test_convert_form(self):
         form_repr = self.encoder.convert_form(TestForm)
         print form_repr
@@ -51,7 +51,7 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             raise
         instance_form_repr = self.encoder.convert_form(TestForm())
         check_schema(instance_form_repr)
-    
+
     def test_convert_charfield(self):
         name = 'a_charfield'
         ideal_repr = {
@@ -59,12 +59,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'string',
             'description': u'Any string',
             'title': 'A charfield',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_charfield(self):
         #CONSIDER: the json spec doesn't define a textarea, this is an option of alpacajs
         name = 'a_textarea'
@@ -73,12 +73,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'string',
             'description': u'Any paragraph',
             'title': 'A textarea',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_urlfield(self):
         name = 'url'
         ideal_repr = {
@@ -87,12 +87,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'format': 'url',
             'description': u'',
             'title': 'Url',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_booleanfield(self):
         name = 'a_boolean'
         ideal_repr = {
@@ -100,12 +100,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'boolean',
             'description': u'',
             'title': 'A boolean',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_select_option(self):
         name = 'select_option'
         ideal_repr = {
@@ -114,12 +114,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'description': u'',
             'title': 'Select option',
             'enum': ['first', 'second'],
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_date(self):
         name = 'a_date'
         ideal_repr = {
@@ -128,12 +128,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'format': 'date',
             'description': u'',
             'title': 'A date',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_datetime(self):
         name = 'a_datetime'
         ideal_repr = {
@@ -142,12 +142,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'format': 'datetime',
             'description': u'',
             'title': 'A datetime',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_decimal(self):
         name = 'a_decimal'
         ideal_repr = {
@@ -155,12 +155,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'number',
             'description': u'',
             'title': 'A decimal',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_email(self):
         name = 'an_email'
         ideal_repr = {
@@ -169,12 +169,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'format': 'email',
             'description': u'',
             'title': 'An email',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_file(self):
         name = 'a_file'
         ideal_repr = {
@@ -183,12 +183,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'format': 'uri',
             'description': u'',
             'title': 'A file',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_float(self):
         name = 'a_float'
         ideal_repr = {
@@ -196,12 +196,12 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'number',
             'description': u'',
             'title': 'A float',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)
         self.assertEqual(schema_repr, ideal_repr)
-    
+
     def test_convert_integer(self):
         name = 'an_integer'
         ideal_repr = {
@@ -209,7 +209,7 @@ class FormToJsonSchemaTestCase(unittest.TestCase):
             'type': 'integer',
             'description': u'',
             'title': 'An integer',
-        } 
+        }
         field = TestForm.base_fields[name]
         json_schema = {'properties':{}}
         schema_repr = self.encoder.convert_formfield(name, field, json_schema)


### PR DESCRIPTION
An instance of a Form is allowed to modify the 'fields' attribute dynamically but convert_to_form() ignores any changes since 'base_fields' is used.   If the object is a Form, the convert_form() method will use the 'fields' attribute.  If the object is a Class, the method will continue to use the 'base_fields' attribute.
